### PR TITLE
Fix hidden field

### DIFF
--- a/src/Forms/Components/TitleWithSlugInput.php
+++ b/src/Forms/Components/TitleWithSlugInput.php
@@ -138,7 +138,7 @@ class TitleWithSlugInput
             ->readOnly($slugIsReadonly)
             ->live(true)
             ->autocomplete(false)
-            ->disableLabel()
+            ->hiddenLabel()
             ->regex($slugRuleRegex)
             ->rules($slugRules)
             ->afterStateUpdated(

--- a/src/Forms/Components/TitleWithSlugInput.php
+++ b/src/Forms/Components/TitleWithSlugInput.php
@@ -78,7 +78,7 @@ class TitleWithSlugInput
                     $fieldSlug,
                     $titleAfterStateUpdated,
                 ) {
-                    $slugAutoUpdateDisabled = $get('slug_auto_update_disabled');
+                    $slugAutoUpdateDisabled = $get($fieldSlug . '_slug_auto_update_disabled');
 
                     if ($context === 'edit' && filled($record)) {
                         $slugAutoUpdateDisabled = true;
@@ -159,7 +159,7 @@ class TitleWithSlugInput
 
                     $set($fieldSlug, self::slugify($slugSlugifier, $text));
 
-                    $set('slug_auto_update_disabled', true);
+                    $set($fieldSlug . '_slug_auto_update_disabled', true);
 
                     if ($slugAfterStateUpdated) {
                         $component->evaluate($slugAfterStateUpdated);
@@ -176,7 +176,7 @@ class TitleWithSlugInput
             : $slugInput->unique(ignorable: fn (?Model $record) => $record);
 
         /** Input: "Slug Auto Update Disabled" (Hidden) */
-        $hiddenInputSlugAutoUpdateDisabled = Hidden::make('slug_auto_update_disabled')
+        $hiddenInputSlugAutoUpdateDisabled = Hidden::make($fieldSlug . '_slug_auto_update_disabled')
             ->dehydrated(false);
 
         /** Group */


### PR DESCRIPTION
The hidden field should use a unique name per instance so multiple instance can be used in the same form.